### PR TITLE
Added configuration options for the loco net

### DIFF
--- a/lib/src/main/java/de/noisruker/locodrive/control/LocoNetHandler.java
+++ b/lib/src/main/java/de/noisruker/locodrive/control/LocoNetHandler.java
@@ -22,7 +22,7 @@ public class LocoNetHandler {
             else if(OS.contains("nix") || OS.contains("nux") || OS.contains("aix"))
                 NativeUtils.loadLibraryFromJar("/liblocodrive.so");
             else if(OS.contains("mac"))
-                NativeUtils.loadLibraryFromJar("/locodrive.dylib");
+                NativeUtils.loadLibraryFromJar("/liblocodrive.dylib");
             else
                 throw new RuntimeException("Not allowed System OS. For support please ask the creator!");
         } catch (java.io.IOException e) {

--- a/lib/src/main/java/de/noisruker/locodrive/control/LocoNetHandler.java
+++ b/lib/src/main/java/de/noisruker/locodrive/control/LocoNetHandler.java
@@ -50,6 +50,20 @@ public class LocoNetHandler {
         LOGGER.info("Successfully connected to port " + this.connector.getPortName());
     }
 
+    public void connectTo(@NotNull String serialPort, long baud_rate, long sending_timeout) throws Exception {
+        if(!Arrays.asList(this.getPortInfos()).contains(serialPort))
+            throw new IllegalArgumentException("The port " + serialPort + " is not available!");
+        this.connector = new LocoNetConnector(serialPort, baud_rate, sending_timeout, this::read, this::handleLack, this::handleError);
+        LOGGER.info("Successfully connected to port " + this.connector.getPortName());
+    }
+
+    public void connectTo(@NotNull String serialPort, long baud_rate, long sending_timeout, long update_cycles, FlowControl flow_control) throws Exception {
+        if(!Arrays.asList(this.getPortInfos()).contains(serialPort))
+            throw new IllegalArgumentException("The port " + serialPort + " is not available!");
+        this.connector = new LocoNetConnector(serialPort, baud_rate, sending_timeout, update_cycles, flow_control, this::read, this::handleLack, this::handleError);
+        LOGGER.info("Successfully connected to port " + this.connector.getPortName());
+    }
+
     public String[] getPortInfos() {
         return PortInfos.getAllPorts();
     }

--- a/lib/src/test/java/de/noisruker/locodrive/LibraryTest.java
+++ b/lib/src/test/java/de/noisruker/locodrive/LibraryTest.java
@@ -61,21 +61,15 @@ public class LibraryTest {
 
             LocoNetHandler.getInstance().startReader();
 
-            LocoNetHandler.getInstance().send(new GpOff());
+            assertTrue(LocoNetHandler.getInstance().send(new GpOff()));
 
-            Thread.sleep(100);
-
-            LocoNetHandler.getInstance().send(new LocoSpd(new SlotArg((short) 7), 100));
-
-            Thread.sleep(100);
+            assertTrue(LocoNetHandler.getInstance().send(new LocoSpd(new SlotArg((short) 7), 100)));
 
             LocoNetHandler.getInstance().stop();
 
-            Thread.sleep(2000);
+            assertFalse(LocoNetHandler.getInstance().send(new LocoSpd(new SlotArg((short) 7), 0)));
 
-            LocoNetHandler.getInstance().send(new LocoSpd(new SlotArg((short) 7), 0));
-
-            LocoNetHandler.getInstance().send(new GpOff());
+            assertFalse(LocoNetHandler.getInstance().send(new GpOff()));
 
             Logger.LOGGER.info("loco net connection was successfully");
         }

--- a/src/args.rs.in
+++ b/src/args.rs.in
@@ -3563,19 +3563,28 @@ pub struct LocoNetConnector {
     error_handler: Box<dyn ExceptionObserver>,
     lack: bool,
     last_message: Message,
-    send: Arc<(Mutex<Vec<u8>>, Condvar)>,
+    send: Arc<(Mutex<Vec<u8>>, Condvar, Condvar)>,
     stop: Mutex<bool>,
-    reading_thread: Option<JoinHandle<()>>
+    reading_thread: Option<JoinHandle<()>>,
+    sending_timeout: u64
 }
 
 impl LocoNetConnector {
-    pub fn new(port_name: &str, message_observer: Box<dyn LocoNetMessageObserver>, lack_observer: Box<dyn LackMessageObserver>, error_handler: Box<dyn ExceptionObserver>) -> Result<Self, String> {
-        let port = serialport::new(port_name, 115_200)
+    pub fn new_norm(port_name: &str, baud_rate: u32, sending_timeout: u64, message_observer: Box<dyn LocoNetMessageObserver>, lack_observer: Box<dyn LackMessageObserver>, error_handler: Box<dyn ExceptionObserver>) -> Result<Self, String> {
+        LocoNetConnector::new(port_name, baud_rate, sending_timeout, 5000, FlowControl::Software, message_observer, lack_observer, error_handler)
+    }
+
+    pub fn new_short(port_name: &str, message_observer: Box<dyn LocoNetMessageObserver>, lack_observer: Box<dyn LackMessageObserver>, error_handler: Box<dyn ExceptionObserver>) -> Result<Self, String> {
+        LocoNetConnector::new(port_name, 115_200, 500, 5000, FlowControl::Software, message_observer, lack_observer, error_handler)
+    }
+
+    pub fn new(port_name: &str, baud_rate: u32, sending_timeout: u64, update_cycles: u64, flow_control: FlowControl, message_observer: Box<dyn LocoNetMessageObserver>, lack_observer: Box<dyn LackMessageObserver>, error_handler: Box<dyn ExceptionObserver>) -> Result<Self, String> {
+        let port = serialport::new(port_name, baud_rate)
             .data_bits(DataBits::Eight)
             .stop_bits(StopBits::Two)
             .parity(Parity::None)
-            .flow_control(FlowControl::Software)
-            .timeout(Duration::from_secs(5))
+            .flow_control(flow_control)
+            .timeout(Duration::from_millis(update_cycles))
             .open();
 
         return if port.is_err() {
@@ -3588,9 +3597,10 @@ impl LocoNetConnector {
                 error_handler,
                 lack: false,
                 last_message: Message::Busy(Busy()),
-                send: Arc::new((Mutex::new(vec![0u8; 0]), Condvar::new())),
+                send: Arc::new((Mutex::new(vec![0u8; 0]), Condvar::new(), Condvar::new())),
                 stop: Mutex::new(false),
                 reading_thread: None,
+                sending_timeout,
             })
         }
     }
@@ -3704,12 +3714,13 @@ impl LocoNetConnector {
 
         // Check for receiving last send message
 
-        let (lock, cvar) = &*self.send;
+        let (lock, cvar, waiter) = &*self.send;
 
         let mut last_send = lock.lock().unwrap();
 
         if !(*last_send).is_empty() && (*last_send) == buf {
             *last_send = vec![0u8; 0];
+            waiter.notify_all();
             cvar.notify_one();
         }
 
@@ -3849,10 +3860,10 @@ impl LocoNetConnector {
 
         let bytes = Self::to_message(message);
 
-        let (lock, cvar) = &*self.send;
+        let (lock, cvar, waiter) = &*self.send;
 
         if !(*lock.lock().unwrap()).is_empty() {
-            let result = cvar.wait_timeout_while(lock.lock().unwrap(), Duration::from_millis(500), |pending| !(*pending).is_empty()).unwrap();
+            let result = cvar.wait_timeout_while(lock.lock().unwrap(), Duration::from_millis(self.sending_timeout), |pending| !(*pending).is_empty()).unwrap();
 
             if result.1.timed_out() {
                 self.error_handler.on_exception_occurred(
@@ -3869,7 +3880,22 @@ impl LocoNetConnector {
         *send = bytes;
 
         match self.port.write_all(&*send) {
-            Ok(_) => true,
+            Ok(_) => {
+                if !(*lock.lock().unwrap()).is_empty() {
+                    let result = waiter.wait_timeout_while(lock.lock().unwrap(), Duration::from_millis(self.sending_timeout), |pending| !(*pending).is_empty()).unwrap();
+
+                    if result.1.timed_out() {
+                        self.error_handler.on_exception_occurred(
+                            MessageParseError::IoError(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut, "Connection timed out! Please check your connected device."
+                                )));
+                        return false;
+                    }
+                }
+
+                true
+            },
             Err(_) => false,
         }
     }
@@ -3885,11 +3911,26 @@ impl LocoNetConnector {
     }
 }
 
+foreign_enum!(enum FlowControl {
+    SOFTWARE = FlowControl::Software,
+    HARDWARE = FlowControl::Hardware,
+    NONE = FlowControl::None,
+});
+
 foreign_class!(class LocoNetConnector {
     self_type LocoNetConnector;
-    constructor LocoNetConnector::new(portName: &str, messageObserver: Box<dyn LocoNetMessageObserver>, lackObserver: Box<dyn LackMessageObserver>, errorHandler: Box<dyn ExceptionObserver>) -> Result<LocoNetConnector, String>;
+    constructor LocoNetConnector::new(port_name: &str, baud_rate: u32, sending_timeout: u64, update_cycles: u64, flow_control: FlowControl, message_observer: Box<dyn LocoNetMessageObserver>, lack_observer: Box<dyn LackMessageObserver>, error_handler: Box<dyn ExceptionObserver>) -> Result<LocoNetConnector, String>;
+    foreign_code r#"
+    public LocoNetConnector(String port_name, long baud_rate, long sending_timeout, LocoNetMessageObserver message_observer, LackMessageObserver lack_observer, ExceptionObserver error_handler) throws Exception {
+        this(port_name, baud_rate, sending_timeout, 5000, FlowControl.SOFTWARE, message_observer, lack_observer, error_handler);
+    }
+
+    public LocoNetConnector(String port_name, LocoNetMessageObserver message_observer, LackMessageObserver lack_observer, ExceptionObserver error_handler) throws Exception {
+        this(port_name, 115_200, 500, 5000, FlowControl.SOFTWARE, message_observer, lack_observer, error_handler);
+    }
+"#;
+
     fn LocoNetConnector::start_reader(&mut self) -> bool; alias startReader;
     fn LocoNetConnector::stop_reader(&mut self); alias stopReader;
     fn LocoNetConnector::get_port_name(&self) -> String; alias getPortName;
 });
-

--- a/src/args.rs.in
+++ b/src/args.rs.in
@@ -3578,6 +3578,7 @@ impl LocoNetConnector {
         LocoNetConnector::new(port_name, 115_200, 500, 5000, FlowControl::Software, message_observer, lack_observer, error_handler)
     }
 
+    //noinspection RsDetachedFile
     pub fn new(port_name: &str, baud_rate: u32, sending_timeout: u64, update_cycles: u64, flow_control: FlowControl, message_observer: Box<dyn LocoNetMessageObserver>, lack_observer: Box<dyn LackMessageObserver>, error_handler: Box<dyn ExceptionObserver>) -> Result<Self, String> {
         let port = serialport::new(port_name, baud_rate)
             .data_bits(DataBits::Eight)
@@ -3713,12 +3714,11 @@ impl LocoNetConnector {
         }
 
         // Check for receiving last send message
-
         let (lock, cvar, waiter) = &*self.send;
-
         let mut last_send = lock.lock().unwrap();
 
         if !(*last_send).is_empty() && (*last_send) == buf {
+            println!("Reset!");
             *last_send = vec![0u8; 0];
             waiter.notify_all();
             cvar.notify_one();
@@ -3881,9 +3881,9 @@ impl LocoNetConnector {
 
         match self.port.write_all(&*send) {
             Ok(_) => {
+                drop(send);
                 if !(*lock.lock().unwrap()).is_empty() {
                     let result = waiter.wait_timeout_while(lock.lock().unwrap(), Duration::from_millis(self.sending_timeout), |pending| !(*pending).is_empty()).unwrap();
-
                     if result.1.timed_out() {
                         self.error_handler.on_exception_occurred(
                             MessageParseError::IoError(
@@ -3893,7 +3893,6 @@ impl LocoNetConnector {
                         return false;
                     }
                 }
-
                 true
             },
             Err(_) => false,


### PR DESCRIPTION
# Changes

List your changes:

| Change   | Short description     |
|----------|-----------------------|
| Change 1 | Added Flow Control Enum |
| Change 2 | Added loco net configuration settings |
| Change 2 | Sending loco net messages returns false, when the message get no response |

# Improvements

You now can edit the baud rate, flow control and timeout times of the loco net connection.

# Logs

Features where tested by me. No log needed every test passed.
